### PR TITLE
Feature/회원가입 및 로그인 구현 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
@@ -36,6 +37,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/company/finsight/api/user/controller/AuthController.java
+++ b/src/main/java/com/company/finsight/api/user/controller/AuthController.java
@@ -2,16 +2,25 @@ package com.company.finsight.api.user.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.company.finsight.api.user.dto.LoginRequest;
 import com.company.finsight.api.user.dto.SignupRequest;
 import com.company.finsight.api.user.dto.SignupResponse;
 import com.company.finsight.api.user.service.UserService;
 import com.company.finsight.global.response.ApiResponse;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 
     private final UserService userService;
+    private final AuthenticationManager authenticationManager;
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<SignupResponse>> signup(@Valid @RequestBody SignupRequest signupRequest) {
@@ -28,6 +38,38 @@ public class AuthController {
             HttpStatus.CREATED,
             "회원가입이 완료되었습니다.",
             userService.signup(signupRequest)
+        );
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<Void>> login(
+        @Valid @RequestBody LoginRequest loginRequest,
+        HttpServletRequest httpRequest
+    ) {
+
+        // 1. 인증 처리
+        Authentication authentication = authenticationManager.authenticate(
+            new UsernamePasswordAuthenticationToken(
+                loginRequest.getUsername(),
+                loginRequest.getPassword()
+            )
+        );
+
+        // 2. SecurityContext에 저장
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+
+        // 3. 세션에 저장
+        HttpSession session = httpRequest.getSession();
+        session.setAttribute(
+            HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
+            context
+        );
+
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "로그인이 완료되었습니다."
         );
     }
 }

--- a/src/main/java/com/company/finsight/api/user/controller/AuthController.java
+++ b/src/main/java/com/company/finsight/api/user/controller/AuthController.java
@@ -7,6 +7,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,6 +21,7 @@ import com.company.finsight.api.user.service.UserService;
 import com.company.finsight.global.response.ApiResponse;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -70,6 +72,30 @@ public class AuthController {
         return ApiResponse.success(
             HttpStatus.OK,
             "로그인이 완료되었습니다."
+        );
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+        HttpServletRequest request,
+        HttpServletResponse response
+    ) {
+
+        // 연결된 Authentication(인증 정보) 객체를 가져옵니다.
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // authentication 객체가 null인지 확인: 사용자가 로그인 상태인지 확인
+        if (authentication != null) {
+            // SecurityContextLogoutHandler는 Spring Security가 제공하는 기본 로그아웃 처리기입니다.
+            // .logout() 메소드를 호출하면 다음 작업들이 자동으로 수행됩니다.
+            // 1. HTTP 세션 무효화 (HttpSession.invalidate())
+            // 2. SecurityContextHolder의 SecurityContext 클리어 (SecurityContextHolder.clearContext())
+            new SecurityContextLogoutHandler().logout(request, response, authentication);
+        }
+
+        return ApiResponse.success(
+            HttpStatus.OK,
+            "로그아웃이 완료되었습니다."
         );
     }
 }

--- a/src/main/java/com/company/finsight/api/user/controller/AuthController.java
+++ b/src/main/java/com/company/finsight/api/user/controller/AuthController.java
@@ -1,0 +1,33 @@
+package com.company.finsight.api.user.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.company.finsight.api.user.dto.SignupRequest;
+import com.company.finsight.api.user.dto.SignupResponse;
+import com.company.finsight.api.user.service.UserService;
+import com.company.finsight.global.response.ApiResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/finsight/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<SignupResponse>> signup(@Valid @RequestBody SignupRequest signupRequest) {
+        return ApiResponse.success(
+            HttpStatus.CREATED,
+            "회원가입이 완료되었습니다.",
+            userService.signup(signupRequest)
+        );
+    }
+}

--- a/src/main/java/com/company/finsight/api/user/dto/LoginRequest.java
+++ b/src/main/java/com/company/finsight/api/user/dto/LoginRequest.java
@@ -1,0 +1,16 @@
+package com.company.finsight.api.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "아이디는 필수입니다.")
+    private String username;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/company/finsight/api/user/dto/SignupRequest.java
+++ b/src/main/java/com/company/finsight/api/user/dto/SignupRequest.java
@@ -1,0 +1,21 @@
+package com.company.finsight.api.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupRequest {
+
+    @NotBlank(message = "아이디는 필수입니다")
+    @Size(min = 4, max = 20)
+    private String username;
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
+        message = "비밀번호는 8자 이상, 영문, 숫자, 특수문자를 포함해야 합니다")
+    private String password;
+}

--- a/src/main/java/com/company/finsight/api/user/dto/SignupResponse.java
+++ b/src/main/java/com/company/finsight/api/user/dto/SignupResponse.java
@@ -1,0 +1,9 @@
+package com.company.finsight.api.user.dto;
+
+import com.company.finsight.api.user.entity.User;
+
+public record SignupResponse(Long userId) {
+    public static SignupResponse from(User user) {
+        return new SignupResponse(user.getId());
+    }
+}

--- a/src/main/java/com/company/finsight/api/user/entity/Role.java
+++ b/src/main/java/com/company/finsight/api/user/entity/Role.java
@@ -1,0 +1,13 @@
+package com.company.finsight.api.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    USER("사용자"),
+    ADMIN("관리자");
+
+    private final String description;
+}

--- a/src/main/java/com/company/finsight/api/user/entity/User.java
+++ b/src/main/java/com/company/finsight/api/user/entity/User.java
@@ -1,0 +1,53 @@
+package com.company.finsight.api.user.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    private String username; // 로그인용 아이디
+    private String password;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    private User(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public static User create(String username, String password) {
+        return new User(username, password);
+    }
+}

--- a/src/main/java/com/company/finsight/api/user/entity/User.java
+++ b/src/main/java/com/company/finsight/api/user/entity/User.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,8 +31,15 @@ public class User {
     @Column(name = "user_id")
     private Long id;
 
+    @Column(nullable = false, unique = true)
     private String username; // 로그인용 아이디
+
+    @Column(nullable = false)
     private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -40,12 +49,16 @@ public class User {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    private User(String username, String password) {
+    private User(String username, String password, Role role) {
         this.username = username;
         this.password = password;
+        this.role = role;
     }
 
     public static User create(String username, String password) {
-        return new User(username, password);
+        return new User(
+            username,
+            password,
+            Role.USER);
     }
 }

--- a/src/main/java/com/company/finsight/api/user/entity/User.java
+++ b/src/main/java/com/company/finsight/api/user/entity/User.java
@@ -12,7 +12,6 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -22,7 +21,6 @@ import lombok.NoArgsConstructor;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class User {
 

--- a/src/main/java/com/company/finsight/api/user/repository/UserRepository.java
+++ b/src/main/java/com/company/finsight/api/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.company.finsight.api.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.company.finsight.api.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByUsername(String username);
+}

--- a/src/main/java/com/company/finsight/api/user/repository/UserRepository.java
+++ b/src/main/java/com/company/finsight/api/user/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package com.company.finsight.api.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.company.finsight.api.user.entity.User;
@@ -7,4 +9,6 @@ import com.company.finsight.api.user.entity.User;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByUsername(String username);
+
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/company/finsight/api/user/service/UserService.java
+++ b/src/main/java/com/company/finsight/api/user/service/UserService.java
@@ -1,0 +1,46 @@
+package com.company.finsight.api.user.service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.company.finsight.api.user.dto.SignupRequest;
+import com.company.finsight.api.user.dto.SignupResponse;
+import com.company.finsight.api.user.entity.User;
+import com.company.finsight.api.user.repository.UserRepository;
+import com.company.finsight.global.exception.business.user.UserErrorCode;
+import com.company.finsight.global.exception.business.user.UserException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * 회원가입 로직
+     * 비밀번호 암호화
+     */
+    @Transactional
+    public SignupResponse signup(SignupRequest signupRequest) {
+
+        // 아이디 중복 검증
+        if (userRepository.existsByUsername(signupRequest.getUsername())) {
+            throw new UserException(UserErrorCode.ALREADY_EXISTS_USERNAME);
+        }
+
+        // 유저 엔티티 생성
+        User user = User.create(
+            signupRequest.getUsername(),
+            passwordEncoder.encode(signupRequest.getPassword()) // 비밀번호 암호화
+        );
+
+        // 유저 엔티티 DB 저장
+        User savedUser = userRepository.save(user);
+
+        return SignupResponse.from(savedUser);
+    }
+}

--- a/src/main/java/com/company/finsight/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/company/finsight/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,12 @@
 package com.company.finsight.global.exception;
 
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -10,20 +16,82 @@ import com.company.finsight.global.response.ApiResponse;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+	/**
+	 * 비즈니스 예외 처리
+	 */
 	@ExceptionHandler(BusinessException.class)
-	public ResponseEntity<ApiResponse<Void>> handler(BusinessException e){
-		return ApiResponse
-			.error(
-				e.getErrorCode().getStatus(),
-				e.getMessage()
-			);
+	public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+		return ApiResponse.error(
+			e.getErrorCode().getStatus(),
+			e.getMessage()
+		);
 	}
 
-	protected ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
-		return ApiResponse
-			.error(
-				e.getErrorCode().getStatus(),
-				e.getMessage()
-			);
+	/**
+	 * @Valid 검증 실패 예외 처리
+	 * 회원가입, 로그인 등 DTO 검증 실패 시
+	 */
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+		// 첫 번째 에러 메시지만 반환
+		String errorMessage = e.getBindingResult()
+			.getFieldErrors()
+			.stream()
+			.map(error -> error.getDefaultMessage())
+			.findFirst()
+			.orElse("입력값이 올바르지 않습니다.");
+
+		return ApiResponse.error(
+			HttpStatus.BAD_REQUEST,
+			errorMessage
+		);
+	}
+
+	/**
+	 * JSON 파싱 실패 예외 처리
+	 * 예) POST /finsight/auth/login
+	 * {"username": "admin", "password": } ← 값 누락
+	 */
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+		return ApiResponse.error(
+			HttpStatus.BAD_REQUEST,
+			"잘못된 요청 형식입니다."
+		);
+	}
+
+	/**
+	 * 예상하지 못한 모든 예외 처리
+	 */
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+		return ApiResponse.error(
+			HttpStatus.INTERNAL_SERVER_ERROR,
+			"서버 오류가 발생했습니다."
+		);
+	}
+
+	// ===================== AuthenticationManager 예외 =====================
+	/**
+	 * 로그인 실패 예외 처리 (비밀번호 틀림)
+	 */
+	@ExceptionHandler(BadCredentialsException.class)
+	public ResponseEntity<ApiResponse<Void>> handleBadCredentials(BadCredentialsException e) {
+		return ApiResponse.error(
+			HttpStatus.UNAUTHORIZED,
+			"아이디 또는 비밀번호가 일치하지 않습니다."
+		);
+	}
+
+	/**
+	 * 사용자를 찾을 수 없음 예외 처리
+	 * 보안상 BadCredentialsException과 동일한 메시지 반환
+	 */
+	@ExceptionHandler(UsernameNotFoundException.class)
+	public ResponseEntity<ApiResponse<Void>> handleUsernameNotFound(UsernameNotFoundException e) {
+		return ApiResponse.error(
+			HttpStatus.UNAUTHORIZED,
+			"아이디 또는 비밀번호가 일치하지 않습니다."
+		);
 	}
 }

--- a/src/main/java/com/company/finsight/global/exception/business/user/UserErrorCode.java
+++ b/src/main/java/com/company/finsight/global/exception/business/user/UserErrorCode.java
@@ -10,7 +10,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-	USER_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 유저를 찾을 수 없습니다.");
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 유저를 찾을 수 없습니다."),
+	ALREADY_EXISTS_USERNAME(HttpStatus.CONFLICT, "이미 존재하는 유저 아이디입니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/company/finsight/global/security/CustomUserDetails.java
+++ b/src/main/java/com/company/finsight/global/security/CustomUserDetails.java
@@ -1,0 +1,50 @@
+package com.company.finsight.global.security;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.company.finsight.api.user.entity.User;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final Long userId;
+    private final String username;
+    private final String password;
+    private final String role;
+
+    public static CustomUserDetails from(User user) {
+        return new CustomUserDetails(
+            user.getId(),
+            user.getUsername(),
+            user.getPassword(),
+            user.getRole().name()
+        );
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(
+            new SimpleGrantedAuthority("ROLE_" + role)
+        );
+    }
+
+    @Override
+    public String getPassword() {
+        return this.password;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.username;
+    }
+}

--- a/src/main/java/com/company/finsight/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/company/finsight/global/security/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package com.company.finsight.global.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.company.finsight.api.user.entity.User;
+import com.company.finsight.api.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        User user = userRepository.findByUsername(username)
+            .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
+
+        return CustomUserDetails.from(user);
+    }
+}

--- a/src/main/java/com/company/finsight/global/security/SecurityConfig.java
+++ b/src/main/java/com/company/finsight/global/security/SecurityConfig.java
@@ -1,0 +1,51 @@
+package com.company.finsight.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+            .csrf(csrf -> csrf.disable()) // csrf 비활성화
+            .formLogin(login -> login.disable()) // security 로그인 비활성화(커스텀 로그인 API 사용 예정)
+            .httpBasic(basic -> basic.disable()) // http basic 비활성화
+
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED) // 필요 시 세션 생성: 로그인 성공 시 세션 생성
+                .sessionFixation().changeSessionId() // 세션 고정 공격 방어 설정: 로그인 성공 후 세션 ID를 변경함
+                .maximumSessions(1) // 동시 로그인 1개만 허용
+                .maxSessionsPreventsLogin(false) // 새 로그인 시 기존 세션 만료: 컴퓨터에서 로그인하면 모바일에서 로그아웃됨
+            )
+
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/finsight/auth/**").permitAll()
+                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .anyRequest().authenticated()
+            )
+
+            .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+        AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}


### PR DESCRIPTION
## 작업 내용

### 사용자 인증 시스템 구현 (세션 기반)

#### 1. Spring Security 설정
  - 세션 관리 방식으로 인증 구현
  - 세션 고정 공격 방어 설정 (`sessionFixation().changeSessionId()`)
  - 동시 로그인 1개 제한 (`maximumSessions(1)`)

  #### 2. User 엔티티 및 권한 관리
  - User 엔티티 구현 (JPA Auditing 적용)
  - Role enum 추가 (`USER`, `ADMIN`)
  - username 중복 방지 (unique 제약조건)
  - 비밀번호 암호화 저장 (BCrypt)

  #### 3. 인증 구현
  - `CustomUserDetails`: UserDetails 구현체 (사용자 정보 + 권한)
  - `CustomUserDetailsService`: DB 기반 사용자 조회
  - `AuthenticationManager` 기반 인증 처리

  #### 4. 회원가입 API
  - **POST** `/finsight/auth/signup`
  - 아이디 중복 검증
  - 비밀번호 검증 (8자 이상, 영문/숫자/특수문자 포함)
  - 비밀번호 암호화 저장

  #### 5. 로그인 API
  - **POST** `/finsight/auth/login`
  - `AuthenticationManager`를 통한 인증
  - `SecurityContext`에 인증 정보 저장
  - 세션 자동 생성 (JSESSIONID 쿠키)

  #### 6. 로그아웃 API
  - **POST** `/finsight/auth/logout`
  - `SecurityContextLogoutHandler`를 통한 세션 무효화
  - SecurityContext 클리어

  #### 7. 전역 예외 처리
  - **Validation 예외**: DTO 검증 실패 시 400 에러
  - **JSON 파싱 예외**: 잘못된 요청 형식 시 400 에러
  - **인증 실패 예외**: 로그인 실패 시 401 에러 (보안상 동일 메시지)
  - **최종 안전망**: 예상치 못한 에러 500 에러 처리

## 관련 이슈

Close #9

### 🔍 리뷰어에게

  #### 1. Spring Security 설정 (`SecurityConfig.java`)

  #### 2. User 엔티티에 Role 추가 (`User.java`, `Role.java`)

  #### 3. 전역 예외 처리 강화 (`GlobalExceptionHandler.java`)
  **추가한 예외 핸들러:**
  - `MethodArgumentNotValidException`: @Valid 검증 실패 → 400 에러
  - `HttpMessageNotReadableException`: JSON 파싱 실패 → 400 에러
  - `BadCredentialsException` / `UsernameNotFoundException`: 로그인 실패 → 401 에러 (보안상 동일 메시지)
  - `Exception`: 최종 안전망 → 500 에러

  **보안 고려사항:**
  - 로그인 실패 시 "사용자 없음"과 "비밀번호 틀림"을 구분하지 않고 동일한 메시지 반환
  - 이유: 유효한 아이디를 해커가 알아내는 것을 방지
