### PR TITLE
feature/1차_크롤링_구현-7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 
+    // 크롤링
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.jsoup:jsoup:1.18.1'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/company/finsight/FiNsightApplication.java
+++ b/src/main/java/com/company/finsight/FiNsightApplication.java
@@ -3,7 +3,9 @@ package com.company.finsight;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class FiNsightApplication {

--- a/src/main/java/com/company/finsight/api/article/client/CrawlerClient.java
+++ b/src/main/java/com/company/finsight/api/article/client/CrawlerClient.java
@@ -1,5 +1,6 @@
 package com.company.finsight.api.article.client;
 
+import lombok.Getter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -9,16 +10,26 @@ public class CrawlerClient {
 
     private final WebClient webClient;
 
+    @Getter
+    private final String ynsBaseUrl = "https://www.yna.co.kr";
+
     // 연합뉴스 Base URL
     public CrawlerClient(WebClient.Builder webClientBuilder) {
         this.webClient = webClientBuilder
-                .baseUrl("https://www.yna.co.kr/industry/")
+                .baseUrl(ynsBaseUrl)
                 .build();
     }
 
     public Mono<String> callIndustEnter() {
         return webClient.get()
-                .uri("/industrial-enterprise")
+                .uri("/industry/industrial-enterprise")
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+
+    public Mono<String> callContent(String uri) {
+        return webClient.get()
+                .uri(uri)
                 .retrieve()
                 .bodyToMono(String.class);
     }

--- a/src/main/java/com/company/finsight/api/article/client/CrawlerClient.java
+++ b/src/main/java/com/company/finsight/api/article/client/CrawlerClient.java
@@ -1,0 +1,25 @@
+package com.company.finsight.api.article.client;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+public class CrawlerClient {
+
+    private final WebClient webClient;
+
+    // 연합뉴스 Base URL
+    public CrawlerClient(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder
+                .baseUrl("https://www.yna.co.kr/industry/")
+                .build();
+    }
+
+    public Mono<String> callIndustEnter() {
+        return webClient.get()
+                .uri("/industrial-enterprise")
+                .retrieve()
+                .bodyToMono(String.class);
+    }
+}

--- a/src/main/java/com/company/finsight/api/article/domain/Article.java
+++ b/src/main/java/com/company/finsight/api/article/domain/Article.java
@@ -1,0 +1,138 @@
+package com.company.finsight.api.article.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "article")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
+public class Article {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "article_cid", unique = true, nullable = false)
+    private String articleCid;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "summary", columnDefinition = "TEXT")
+    private String summary;
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "category")
+    private String category;
+
+    @Column(name = "reporter")
+    private String reporter;
+
+    @Column(name = "source")
+    private String source;
+
+    @Column(name = "keywords")
+    private String keywords;
+
+    @Column(name = "article_url", unique = true, nullable = false)
+    private String articleUrl;
+
+    @Column(name = "thumbnail_url")
+    private String thumbnailUrl;
+
+    @Column(name = "published_at", nullable = false)
+    private LocalDateTime publishedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public Article() {}
+
+    /**
+     * Article 엔티티 생성 (정적 팩토리 메서드)
+     *
+     * @param articleCid 연합뉴스 기사 고유 ID
+     * @param title 기사 제목
+     * @param summary 기사 요약
+     * @param content 기사 본문
+     * @param category 카테고리
+     * @param reporter 기자 이름
+     * @param source 뉴스 출처
+     * @param keywords 키워드
+     * @param articleUrl 기사 원문 URL
+     * @param thumbnailUrl 썸네일 이미지 URL
+     * @param publishedAt 기사 발행 시간
+     * @return Article 엔티티
+     */
+    public static Article create(
+            String articleCid,
+            String title,
+            String summary,
+            String content,
+            String category,
+            String reporter,
+            String source,
+            String keywords,
+            String articleUrl,
+            String thumbnailUrl,
+            LocalDateTime publishedAt
+    ) {
+        Article article = new Article();
+        article.articleCid = articleCid;
+        article.title = title;
+        article.summary = summary;
+        article.content = content;
+        article.category = category;
+        article.reporter = reporter;
+        article.source = source;
+        article.keywords = keywords;
+        article.articleUrl = articleUrl;
+        article.thumbnailUrl = thumbnailUrl;
+        article.publishedAt = publishedAt;
+        return article;
+    }
+
+    /**
+     * 필수 필드만으로 Article 엔티티 생성
+     *
+     * @param articleCid 연합뉴스 기사 고유 ID
+     * @param title 기사 제목
+     * @param articleUrl 기사 원문 URL
+     * @param publishedAt 기사 발행 시간
+     * @return Article 엔티티
+     */
+    public static Article createWithRequired(
+            String articleCid,
+            String title,
+            String articleUrl,
+            LocalDateTime publishedAt
+    ) {
+        return create(
+                articleCid,
+                title,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                articleUrl,
+                null,
+                publishedAt
+        );
+    }
+}

--- a/src/main/java/com/company/finsight/api/article/domain/Article.java
+++ b/src/main/java/com/company/finsight/api/article/domain/Article.java
@@ -71,7 +71,7 @@ public class Article {
      * @param category 카테고리
      * @param reporter 기자 이름
      * @param source 뉴스 출처
-     * @param keywords 키워드
+     * @param keyword 키워드
      * @param articleUrl 기사 원문 URL
      * @param thumbnailUrl 썸네일 이미지 URL
      * @param publishedAt 기사 발행 시간

--- a/src/main/java/com/company/finsight/api/article/domain/Article.java
+++ b/src/main/java/com/company/finsight/api/article/domain/Article.java
@@ -40,7 +40,7 @@ public class Article {
     private String source;
 
     @Column(name = "keywords")
-    private String keywords;
+    private String keyword;
 
     @Column(name = "article_url", unique = true, nullable = false)
     private String articleUrl;
@@ -85,7 +85,7 @@ public class Article {
             String category,
             String reporter,
             String source,
-            String keywords,
+            String keyword,
             String articleUrl,
             String thumbnailUrl,
             LocalDateTime publishedAt
@@ -98,7 +98,7 @@ public class Article {
         article.category = category;
         article.reporter = reporter;
         article.source = source;
-        article.keywords = keywords;
+        article.keyword = keyword;
         article.articleUrl = articleUrl;
         article.thumbnailUrl = thumbnailUrl;
         article.publishedAt = publishedAt;

--- a/src/main/java/com/company/finsight/api/article/domain/Article.java
+++ b/src/main/java/com/company/finsight/api/article/domain/Article.java
@@ -104,34 +104,4 @@ public class Article {
         article.publishedAt = publishedAt;
         return article;
     }
-
-    /**
-     * 필수 필드만으로 Article 엔티티 생성
-     *
-     * @param articleCid 연합뉴스 기사 고유 ID
-     * @param title 기사 제목
-     * @param articleUrl 기사 원문 URL
-     * @param publishedAt 기사 발행 시간
-     * @return Article 엔티티
-     */
-    public static Article createWithRequired(
-            String articleCid,
-            String title,
-            String articleUrl,
-            LocalDateTime publishedAt
-    ) {
-        return create(
-                articleCid,
-                title,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                articleUrl,
-                null,
-                publishedAt
-        );
-    }
 }

--- a/src/main/java/com/company/finsight/api/article/domain/Article.java
+++ b/src/main/java/com/company/finsight/api/article/domain/Article.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "article")
 @Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @EntityListeners(AuditingEntityListener.class)
 public class Article {
 

--- a/src/main/java/com/company/finsight/api/article/dto/ArticleContentDto.java
+++ b/src/main/java/com/company/finsight/api/article/dto/ArticleContentDto.java
@@ -1,0 +1,11 @@
+package com.company.finsight.api.article.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ArticleContentDto {
+    private String content;
+    private String reporter;
+}

--- a/src/main/java/com/company/finsight/api/article/dto/ArticleDto.java
+++ b/src/main/java/com/company/finsight/api/article/dto/ArticleDto.java
@@ -1,0 +1,26 @@
+package com.company.finsight.api.article.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@Builder
+@AllArgsConstructor
+public class ArticleDto {
+    private String articleCid;       // 연합뉴스 기사 ID
+    private String title;            // 제목
+    private String summary;          // 요약
+    // private String content;       // 본문은 나중에 별도로 가져와야 함
+    private String category;         // 카테고리 (여기서는 "산업/기업")
+    // private String reporter;      // 기자 이름은 본문 페이지에 있음
+    private String source;           // 출처 (기본값: "연합뉴스")
+    private String keywords;         // 키워드 (본문 페이지에 있음)
+    private String articleUrl;       // 기사 원문 URL
+    private String thumbnailUrl;     // 썸네일 URL
+    private LocalDateTime publishedAt; // 발행 시간
+}

--- a/src/main/java/com/company/finsight/api/article/dto/ArticleSummaryDto.java
+++ b/src/main/java/com/company/finsight/api/article/dto/ArticleSummaryDto.java
@@ -11,15 +11,12 @@ import java.time.LocalDateTime;
 @ToString
 @Builder
 @AllArgsConstructor
-public class ArticleDto {
+public class ArticleSummaryDto {
     private String articleCid;       // 연합뉴스 기사 ID
     private String title;            // 제목
     private String summary;          // 요약
-    // private String content;       // 본문은 나중에 별도로 가져와야 함
     private String category;         // 카테고리 (여기서는 "산업/기업")
-    // private String reporter;      // 기자 이름은 본문 페이지에 있음
     private String source;           // 출처 (기본값: "연합뉴스")
-    private String keywords;         // 키워드 (본문 페이지에 있음)
     private String articleUrl;       // 기사 원문 URL
     private String thumbnailUrl;     // 썸네일 URL
     private LocalDateTime publishedAt; // 발행 시간

--- a/src/main/java/com/company/finsight/api/article/repository/ArticleRepository.java
+++ b/src/main/java/com/company/finsight/api/article/repository/ArticleRepository.java
@@ -1,0 +1,7 @@
+package com.company.finsight.api.article.repository;
+
+import com.company.finsight.api.article.domain.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article,Long> {
+}

--- a/src/main/java/com/company/finsight/api/article/service/ArticleParser.java
+++ b/src/main/java/com/company/finsight/api/article/service/ArticleParser.java
@@ -1,6 +1,7 @@
 package com.company.finsight.api.article.service;
 
-import com.company.finsight.api.article.dto.ArticleDto;
+import com.company.finsight.api.article.dto.ArticleContentDto;
+import com.company.finsight.api.article.dto.ArticleSummaryDto;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -18,9 +19,9 @@ import java.util.List;
 @Component
 public class ArticleParser {
 
-    public Mono<List<ArticleDto>> parseArticleList(String htmlContent, String categoryName) {
+    public Mono<List<ArticleSummaryDto>> parseArticleList(String htmlContent, String categoryName, String baseUrl) {
         return Mono.fromCallable(() -> {
-            List<ArticleDto> articleDtoList = new ArrayList<>();
+            List<ArticleSummaryDto> articleDtoList = new ArrayList<>();
             Document doc = Jsoup.parse(htmlContent);
             Elements articleElements = doc.select("div.list-type212 > ul.list01 > li");
 
@@ -44,13 +45,13 @@ public class ArticleParser {
                             // 시간 파싱
                             LocalDateTime publishedAt = parseApproximateDateTime(timeStr);
 
-                            ArticleDto dto = ArticleDto.builder()
+                            ArticleSummaryDto dto = ArticleSummaryDto.builder()
                                     .articleCid(cid)
                                     .title(title)
                                     .summary(summary)
                                     .category(categoryName)
                                     .source("연합뉴스")
-                                    .articleUrl(fullUrl)
+                                    .articleUrl(fullUrl.replace(baseUrl, ""))
                                     .thumbnailUrl(thumbnailUrl)
                                     .publishedAt(publishedAt)
                                     .build();
@@ -68,6 +69,64 @@ public class ArticleParser {
             }
             log.info("파싱 성공 개수 {} 카테고리 : {}", articleDtoList.size(), categoryName);
             return articleDtoList;
+        });
+    }
+
+    public Mono<ArticleContentDto> parseArticleContent(String htmlContent) {
+        return Mono.fromCallable(() -> {
+            Document doc = Jsoup.parse(htmlContent);
+            Element articleBodyElement = doc.selectFirst("article#articleWrap div.story-news.article");
+            String content = "";
+            if (articleBodyElement != null) {
+                content = articleBodyElement.text();
+
+                // 광고 문구 제거
+                content = content.replaceFirst("^\\s*\\([^)]+\\)\\s*", "").trim();
+
+                String emailDomain = "@yna.co.kr";
+                int emailDomainIndex = content.indexOf(emailDomain); // "@yna.co.kr" 시작 위치 찾기
+
+                if (emailDomainIndex != -1) {
+                    int endIndex = emailDomainIndex + emailDomain.length();
+                    content = content.substring(0, endIndex).trim();
+                } else {
+                    // 이메일 주소가 없는 경우
+                    int jeboIndex = content.indexOf("제보");
+                    if (jeboIndex != -1) {
+                        content = content.substring(0, jeboIndex).trim();
+                    }
+                    // 저작권 문구
+                    int copyrightIndex = content.indexOf("<저작권자(c) 연합뉴스");
+                    if (copyrightIndex != -1) {
+                        content = content.substring(0, copyrightIndex).trim();
+                    }
+                }
+
+            } else {
+                log.warn("Article body element not found.");
+            }
+
+            // 작성자 이름 추출
+            Element reporterElement = doc.selectFirst("div.writer-zone01 strong.tit-name > a");
+            String reporter = "";
+            if (reporterElement != null) {
+                reporter = reporterElement.text();
+            } else {
+                // 작성자 정보가 없는 기사
+                log.info("작성자 파악 불가");
+                // 또는 메타 태그에서 시도
+                Element metaAuthor = doc.selectFirst("meta[name=author]");
+                if (metaAuthor != null) {
+                    reporter = metaAuthor.attr("content");
+                }
+            }
+
+            if (!content.isEmpty() || !reporter.isEmpty()) {
+                return new ArticleContentDto(content, reporter);
+            } else {
+                log.warn("본문, 작성자 파싱 실패.");
+                return null;
+            }
         });
     }
 

--- a/src/main/java/com/company/finsight/api/article/service/ArticleParser.java
+++ b/src/main/java/com/company/finsight/api/article/service/ArticleParser.java
@@ -58,15 +58,15 @@ public class ArticleParser {
 
                             log.debug("Parsed article: {}", dto);
                         } else {
-                            log.warn("Skipping article element due to missing fields (title, summary, or time). CID: {}", cid);
+                            log.warn("필드가 없을 경우 (title, summary, time). CID: {}", cid);
                         }
                     } catch (Exception e) {
                         // 특정 기사 파싱 중 에러 발생 시 로그 남기고 계속 진행
-                        log.error("Error parsing article element: {}", articleElement.html(), e);
+                        log.error("파싱 실패 : {}", articleElement.html(), e);
                     }
                 }
             }
-            log.info("Successfully parsed {} articles from category '{}'", articleDtoList.size(), categoryName);
+            log.info("파싱 성공 개수 {} 카테고리 : {}", articleDtoList.size(), categoryName);
             return articleDtoList;
         });
     }
@@ -80,7 +80,7 @@ public class ArticleParser {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
             return LocalDateTime.parse(yearAndTimeStr, formatter);
         } catch (Exception e) {
-            log.warn("Failed to parse approximate datetime: {}", timeStr, e);
+            log.warn("시간 변환 실패: {}", timeStr, e);
             return null;
         }
     }

--- a/src/main/java/com/company/finsight/api/article/service/ArticleParser.java
+++ b/src/main/java/com/company/finsight/api/article/service/ArticleParser.java
@@ -1,0 +1,87 @@
+package com.company.finsight.api.article.service;
+
+import com.company.finsight.api.article.dto.ArticleDto;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+public class ArticleParser {
+
+    public Mono<List<ArticleDto>> parseArticleList(String htmlContent, String categoryName) {
+        return Mono.fromCallable(() -> {
+            List<ArticleDto> articleDtoList = new ArrayList<>();
+            Document doc = Jsoup.parse(htmlContent);
+            Elements articleElements = doc.select("div.list-type212 > ul.list01 > li");
+
+            log.info("{}개의 아티클을 찾았습니다. 카테고리 : '{}'", articleElements.size(), categoryName);
+            for (Element articleElement : articleElements) {
+                if (articleElement.hasAttr("data-cid")) {
+                    try {
+                        String cid = articleElement.attr("data-cid");
+                        Element titleLink = articleElement.selectFirst("a.tit-news");
+                        Element summaryElement = articleElement.selectFirst("p.lead");
+                        Element timeElement = articleElement.selectFirst("span.txt-time");
+                        Element imgElement = articleElement.selectFirst("figure.img-con01 img"); // 이미지 태그 선택
+
+                        if (titleLink != null && summaryElement != null && timeElement != null) {
+                            String title = titleLink.text();
+                            String fullUrl = titleLink.absUrl("href");
+                            String summary = summaryElement.text();
+                            String timeStr = timeElement.text(); // 예: "10-26 17:18"
+                            String thumbnailUrl = (imgElement != null) ? imgElement.attr("src") : null; // 썸네일 URL 추출
+
+                            // 시간 파싱
+                            LocalDateTime publishedAt = parseApproximateDateTime(timeStr);
+
+                            ArticleDto dto = ArticleDto.builder()
+                                    .articleCid(cid)
+                                    .title(title)
+                                    .summary(summary)
+                                    .category(categoryName)
+                                    .source("연합뉴스")
+                                    .articleUrl(fullUrl)
+                                    .thumbnailUrl(thumbnailUrl)
+                                    .publishedAt(publishedAt)
+                                    .build();
+                            articleDtoList.add(dto);
+
+                            log.debug("Parsed article: {}", dto);
+                        } else {
+                            log.warn("Skipping article element due to missing fields (title, summary, or time). CID: {}", cid);
+                        }
+                    } catch (Exception e) {
+                        // 특정 기사 파싱 중 에러 발생 시 로그 남기고 계속 진행
+                        log.error("Error parsing article element: {}", articleElement.html(), e);
+                    }
+                }
+            }
+            log.info("Successfully parsed {} articles from category '{}'", articleDtoList.size(), categoryName);
+            return articleDtoList;
+        });
+    }
+
+    // 목록 페이지 시간 문자열 파싱
+    private LocalDateTime parseApproximateDateTime(String timeStr) {
+        try {
+            // 현재 연도 가져오기
+            int currentYear = LocalDateTime.now(java.time.ZoneId.of("Asia/Seoul")).getYear();
+            String yearAndTimeStr = currentYear + "-" + timeStr; // 예: "2025-10-26 17:18"
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+            return LocalDateTime.parse(yearAndTimeStr, formatter);
+        } catch (Exception e) {
+            log.warn("Failed to parse approximate datetime: {}", timeStr, e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/company/finsight/api/article/service/ArticleService.java
+++ b/src/main/java/com/company/finsight/api/article/service/ArticleService.java
@@ -1,11 +1,15 @@
 package com.company.finsight.api.article.service;
 
 import com.company.finsight.api.article.client.CrawlerClient;
+import com.company.finsight.api.article.domain.Article;
+import com.company.finsight.api.article.dto.ArticleSummaryDto;
 import com.company.finsight.api.article.repository.ArticleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -22,17 +26,31 @@ public class ArticleService {
         String category = "산업/기업"; // 현재 크롤링 중인 카테고리명
 
         crawlerClient.callIndustEnter() // HTML 가져오기 (Mono<String>)
-                .flatMap(html -> articleParser.parseArticleList(html, category)) // HTML 파싱하여 DTO 리스트 생성 (Mono<List<ArticleDto>>)
+                .flatMap(html -> articleParser.parseArticleList(html, category, crawlerClient.getYnsBaseUrl())) // HTML 파싱하여 DTO 리스트 생성 (Mono<List<ArticleDto>>)
                 .doOnNext(articleList -> {
                     log.info("파싱 결과 개수 : {}, 카테고리 : {}", articleList.size(), category);
-                    // TODO: 여기서 articleList를 반복하며 DB에 저장하는 로직 작성
-                    // TODO: 본문 추가 호출 및 파싱 구현 필요
+                    callContent(articleList);
                 })
                 .doOnError(error -> {
                     log.error("크롤링 실패 카테고리 : {}", category, error);
                 })
                 .subscribe(); // 실행
         log.info("스케줄링 종료...");
+    }
+
+    private void callContent(List<ArticleSummaryDto> articleList) {
+        for(ArticleSummaryDto article : articleList) {
+            crawlerClient.callContent(article.getArticleUrl())
+                    .flatMap(articleParser::parseArticleContent)
+                    .doOnNext(articleContent -> {
+                       // TODO: 여기서 DB에 저장하는 로직 작성
+                        log.info("본문 {} : 기자 {}", articleContent.getContent(), articleContent.getReporter());
+                    })
+                    .doOnError(error -> {
+                        log.error("본문 크롤링 실패 : {}", article.getArticleCid(), error);
+                    })
+                    .subscribe();
+        }
     }
 
 

--- a/src/main/java/com/company/finsight/api/article/service/ArticleService.java
+++ b/src/main/java/com/company/finsight/api/article/service/ArticleService.java
@@ -4,12 +4,17 @@ import com.company.finsight.api.article.client.CrawlerClient;
 import com.company.finsight.api.article.domain.Article;
 import com.company.finsight.api.article.dto.ArticleSummaryDto;
 import com.company.finsight.api.article.repository.ArticleRepository;
+import com.company.finsight.global.Const;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import reactor.core.scheduler.Schedulers;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Random;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -20,7 +25,7 @@ public class ArticleService {
     private final ArticleParser articleParser;
     private final ArticleRepository articleRepository;
 
-    @Scheduled(fixedRate = 10000)
+    @Scheduled(fixedRate = 900000)
     public void test() {
         log.info("스케줄링 시작...");
         String category = "산업/기업"; // 현재 크롤링 중인 카테고리명
@@ -39,19 +44,49 @@ public class ArticleService {
     }
 
     private void callContent(List<ArticleSummaryDto> articleList) {
-        for(ArticleSummaryDto article : articleList) {
-            crawlerClient.callContent(article.getArticleUrl())
+        for(ArticleSummaryDto articleSummary : articleList) {
+            crawlerClient.callContent(articleSummary.getArticleUrl())
                     .flatMap(articleParser::parseArticleContent)
+                    .publishOn(Schedulers.boundedElastic())
                     .doOnNext(articleContent -> {
-                       // TODO: 여기서 DB에 저장하는 로직 작성
                         log.info("본문 {} : 기자 {}", articleContent.getContent(), articleContent.getReporter());
+                        // TODO 키워드 세팅
+                        Article article = Article.create(
+                            articleSummary.getArticleCid(), articleSummary.getTitle(), articleSummary.getSummary(),
+                            articleContent.getContent(), articleSummary.getCategory(), articleContent.getReporter(),
+                            articleSummary.getSource(), findKeywords(articleContent.getContent()), articleSummary.getArticleUrl(),
+                            articleSummary.getThumbnailUrl(), articleSummary.getPublishedAt()
+                        );
+                        articleRepository.save(article);
                     })
                     .doOnError(error -> {
-                        log.error("본문 크롤링 실패 : {}", article.getArticleCid(), error);
+                        log.error("본문 크롤링 실패 : {}", articleSummary.getArticleCid(), error);
                     })
                     .subscribe();
+
+            // 크롤링 대기 시간 설정
+            try {
+                Random random = new Random();
+                int min = 5000;
+                int max = 15000;
+                int randomNumber = random.nextInt(max - min + 1) + min;
+                Thread.sleep(randomNumber);
+                log.info("저장 성공");
+            } catch (InterruptedException e) {
+                log.error(e.getMessage(), e);
+                Thread.currentThread().interrupt();
+            }
         }
     }
 
+    private String findKeywords(String content) {
+        Set<String> keywords = new HashSet<>();
+        for(String keyword : Const.KEYWORDS) {
+            if(content.contains(keyword)) {
+                keywords.add(keyword);
+            }
+        }
+        return String.join(", ", keywords);
+    }
 
 }

--- a/src/main/java/com/company/finsight/api/article/service/ArticleService.java
+++ b/src/main/java/com/company/finsight/api/article/service/ArticleService.java
@@ -2,6 +2,7 @@ package com.company.finsight.api.article.service;
 
 import com.company.finsight.api.article.client.CrawlerClient;
 import com.company.finsight.api.article.dto.ArticleDto;
+import com.company.finsight.api.article.repository.ArticleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
@@ -24,6 +25,8 @@ import java.util.List;
 public class ArticleService {
 
     private final CrawlerClient crawlerClient;
+    private final ArticleParser articleParser;
+    private final ArticleRepository articleRepository;
 
     @Scheduled(fixedRate = 10000)
     public void test() {
@@ -31,10 +34,11 @@ public class ArticleService {
         String category = "산업/기업"; // 현재 크롤링 중인 카테고리명
 
         crawlerClient.callIndustEnter() // HTML 가져오기 (Mono<String>)
-                .flatMap(html -> parseArticleList(html, category)) // HTML 파싱하여 DTO 리스트 생성 (Mono<List<ArticleDto>>)
+                .flatMap(html -> articleParser.parseArticleList(html, category)) // HTML 파싱하여 DTO 리스트 생성 (Mono<List<ArticleDto>>)
                 .doOnNext(articleList -> {
                     log.info("파싱 결과 개수 : {}, 카테고리 : {}", articleList.size(), category);
                     // TODO: 여기서 articleList를 반복하며 DB에 저장하는 로직 작성
+                    // TODO: 본문 추가 호출 및 파싱 구현 필요
                 })
                 .doOnError(error -> {
                     log.error("크롤링 실패 카테고리 : {}", category, error);
@@ -43,70 +47,5 @@ public class ArticleService {
         log.info("스케줄링 종료...");
     }
 
-    public Mono<List<ArticleDto>> parseArticleList(String htmlContent, String categoryName) {
-        return Mono.fromCallable(() -> {
-            List<ArticleDto> articleDtoList = new ArrayList<>();
-            Document doc = Jsoup.parse(htmlContent);
-            Elements articleElements = doc.select("div.list-type212 > ul.list01 > li");
 
-            log.info("{}개의 아티클을 찾았습니다. 카테고리 : '{}'", articleElements.size(), categoryName);
-            for (Element articleElement : articleElements) {
-                if (articleElement.hasAttr("data-cid")) {
-                    try {
-                        String cid = articleElement.attr("data-cid");
-                        Element titleLink = articleElement.selectFirst("a.tit-news");
-                        Element summaryElement = articleElement.selectFirst("p.lead");
-                        Element timeElement = articleElement.selectFirst("span.txt-time");
-                        Element imgElement = articleElement.selectFirst("figure.img-con01 img"); // 이미지 태그 선택
-
-                        if (titleLink != null && summaryElement != null && timeElement != null) {
-                            String title = titleLink.text();
-                            String fullUrl = titleLink.absUrl("href");
-                            String summary = summaryElement.text();
-                            String timeStr = timeElement.text(); // 예: "10-26 17:18"
-                            String thumbnailUrl = (imgElement != null) ? imgElement.attr("src") : null; // 썸네일 URL 추출
-
-                            // 시간 파싱
-                            LocalDateTime publishedAt = parseApproximateDateTime(timeStr);
-
-                            ArticleDto dto = ArticleDto.builder()
-                                    .articleCid(cid)
-                                    .title(title)
-                                    .summary(summary)
-                                    .category(categoryName)
-                                    .source("연합뉴스")
-                                    .articleUrl(fullUrl)
-                                    .thumbnailUrl(thumbnailUrl)
-                                    .publishedAt(publishedAt)
-                                    .build();
-                            articleDtoList.add(dto);
-
-                            log.debug("Parsed article: {}", dto);
-                        } else {
-                            log.warn("Skipping article element due to missing fields (title, summary, or time). CID: {}", cid);
-                        }
-                    } catch (Exception e) {
-                        // 특정 기사 파싱 중 에러 발생 시 로그 남기고 계속 진행
-                        log.error("Error parsing article element: {}", articleElement.html(), e);
-                    }
-                }
-            }
-            log.info("Successfully parsed {} articles from category '{}'", articleDtoList.size(), categoryName);
-            return articleDtoList;
-        });
-    }
-
-    // 목록 페이지 시간 문자열 파싱
-    private LocalDateTime parseApproximateDateTime(String timeStr) {
-        try {
-            // 현재 연도 가져오기
-            int currentYear = LocalDateTime.now(java.time.ZoneId.of("Asia/Seoul")).getYear();
-            String yearAndTimeStr = currentYear + "-" + timeStr; // 예: "2025-10-26 17:18"
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
-            return LocalDateTime.parse(yearAndTimeStr, formatter);
-        } catch (Exception e) {
-            log.warn("Failed to parse approximate datetime: {}", timeStr, e);
-            return null;
-        }
-    }
 }

--- a/src/main/java/com/company/finsight/api/article/service/ArticleService.java
+++ b/src/main/java/com/company/finsight/api/article/service/ArticleService.java
@@ -1,0 +1,112 @@
+package com.company.finsight.api.article.service;
+
+import com.company.finsight.api.article.client.CrawlerClient;
+import com.company.finsight.api.article.dto.ArticleDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ArticleService {
+
+    private final CrawlerClient crawlerClient;
+
+    @Scheduled(fixedRate = 10000)
+    public void test() {
+        log.info("스케줄링 시작...");
+        String category = "산업/기업"; // 현재 크롤링 중인 카테고리명
+
+        crawlerClient.callIndustEnter() // HTML 가져오기 (Mono<String>)
+                .flatMap(html -> parseArticleList(html, category)) // HTML 파싱하여 DTO 리스트 생성 (Mono<List<ArticleDto>>)
+                .doOnNext(articleList -> {
+                    log.info("파싱 결과 개수 : {}, 카테고리 : {}", articleList.size(), category);
+                    // TODO: 여기서 articleList를 반복하며 DB에 저장하는 로직 작성
+                })
+                .doOnError(error -> {
+                    log.error("크롤링 실패 카테고리 : {}", category, error);
+                })
+                .subscribe(); // 실행
+        log.info("스케줄링 종료...");
+    }
+
+    public Mono<List<ArticleDto>> parseArticleList(String htmlContent, String categoryName) {
+        return Mono.fromCallable(() -> {
+            List<ArticleDto> articleDtoList = new ArrayList<>();
+            Document doc = Jsoup.parse(htmlContent);
+            Elements articleElements = doc.select("div.list-type212 > ul.list01 > li");
+
+            log.info("{}개의 아티클을 찾았습니다. 카테고리 : '{}'", articleElements.size(), categoryName);
+            for (Element articleElement : articleElements) {
+                if (articleElement.hasAttr("data-cid")) {
+                    try {
+                        String cid = articleElement.attr("data-cid");
+                        Element titleLink = articleElement.selectFirst("a.tit-news");
+                        Element summaryElement = articleElement.selectFirst("p.lead");
+                        Element timeElement = articleElement.selectFirst("span.txt-time");
+                        Element imgElement = articleElement.selectFirst("figure.img-con01 img"); // 이미지 태그 선택
+
+                        if (titleLink != null && summaryElement != null && timeElement != null) {
+                            String title = titleLink.text();
+                            String fullUrl = titleLink.absUrl("href");
+                            String summary = summaryElement.text();
+                            String timeStr = timeElement.text(); // 예: "10-26 17:18"
+                            String thumbnailUrl = (imgElement != null) ? imgElement.attr("src") : null; // 썸네일 URL 추출
+
+                            // 시간 파싱
+                            LocalDateTime publishedAt = parseApproximateDateTime(timeStr);
+
+                            ArticleDto dto = ArticleDto.builder()
+                                    .articleCid(cid)
+                                    .title(title)
+                                    .summary(summary)
+                                    .category(categoryName)
+                                    .source("연합뉴스")
+                                    .articleUrl(fullUrl)
+                                    .thumbnailUrl(thumbnailUrl)
+                                    .publishedAt(publishedAt)
+                                    .build();
+                            articleDtoList.add(dto);
+
+                            log.debug("Parsed article: {}", dto);
+                        } else {
+                            log.warn("Skipping article element due to missing fields (title, summary, or time). CID: {}", cid);
+                        }
+                    } catch (Exception e) {
+                        // 특정 기사 파싱 중 에러 발생 시 로그 남기고 계속 진행
+                        log.error("Error parsing article element: {}", articleElement.html(), e);
+                    }
+                }
+            }
+            log.info("Successfully parsed {} articles from category '{}'", articleDtoList.size(), categoryName);
+            return articleDtoList;
+        });
+    }
+
+    // 목록 페이지 시간 문자열 파싱
+    private LocalDateTime parseApproximateDateTime(String timeStr) {
+        try {
+            // 현재 연도 가져오기
+            int currentYear = LocalDateTime.now(java.time.ZoneId.of("Asia/Seoul")).getYear();
+            String yearAndTimeStr = currentYear + "-" + timeStr; // 예: "2025-10-26 17:18"
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+            return LocalDateTime.parse(yearAndTimeStr, formatter);
+        } catch (Exception e) {
+            log.warn("Failed to parse approximate datetime: {}", timeStr, e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/company/finsight/api/article/service/ArticleService.java
+++ b/src/main/java/com/company/finsight/api/article/service/ArticleService.java
@@ -1,23 +1,11 @@
 package com.company.finsight.api.article.service;
 
 import com.company.finsight.api.article.client.CrawlerClient;
-import com.company.finsight.api.article.dto.ArticleDto;
 import com.company.finsight.api.article.repository.ArticleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jsoup.Jsoup;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import reactor.core.publisher.Mono;
-
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 @Service

--- a/src/main/java/com/company/finsight/api/article/service/ArticleService.java
+++ b/src/main/java/com/company/finsight/api/article/service/ArticleService.java
@@ -36,9 +36,7 @@ public class ArticleService {
                     log.info("파싱 결과 개수 : {}, 카테고리 : {}", articleList.size(), category);
                     callContent(articleList);
                 })
-                .doOnError(error -> {
-                    log.error("크롤링 실패 카테고리 : {}", category, error);
-                })
+                .doOnError(error -> log.error("크롤링 실패 카테고리 : {}", category, error))
                 .subscribe(); // 실행
         log.info("스케줄링 종료...");
     }
@@ -58,9 +56,7 @@ public class ArticleService {
                         );
                         articleRepository.save(article);
                     })
-                    .doOnError(error -> {
-                        log.error("본문 크롤링 실패 : {}", articleSummary.getArticleCid(), error);
-                    })
+                    .doOnError(error -> log.error("본문 크롤링 실패 : {}", articleSummary.getArticleCid(), error))
                     .subscribe();
 
             // 크롤링 대기 시간 설정

--- a/src/main/java/com/company/finsight/api/article/service/ArticleService.java
+++ b/src/main/java/com/company/finsight/api/article/service/ArticleService.java
@@ -50,7 +50,6 @@ public class ArticleService {
                     .publishOn(Schedulers.boundedElastic())
                     .doOnNext(articleContent -> {
                         log.info("본문 {} : 기자 {}", articleContent.getContent(), articleContent.getReporter());
-                        // TODO 키워드 세팅
                         Article article = Article.create(
                             articleSummary.getArticleCid(), articleSummary.getTitle(), articleSummary.getSummary(),
                             articleContent.getContent(), articleSummary.getCategory(), articleContent.getReporter(),

--- a/src/main/java/com/company/finsight/global/Const.java
+++ b/src/main/java/com/company/finsight/global/Const.java
@@ -1,0 +1,17 @@
+package com.company.finsight.global;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class Const {
+
+    public static final Set<String> KEYWORDS = new HashSet<>(Arrays.asList(
+            "실적", "공시", "증시", "금리", "주가", "상승", "하락",
+            "매수", "매도", "외국인", "기관", "개인",
+            "유상증자", "무상증자", "자사주", "배당", "M&A", "인수", "합병",
+            "특허", "신약", "임상",
+            "반도체", "AI", "배터리",
+            "삼성전자", "SK하이닉스", "현대차"
+    ));
+}

--- a/src/main/java/com/company/finsight/global/config/WebClientConfig.java
+++ b/src/main/java/com/company/finsight/global/config/WebClientConfig.java
@@ -1,0 +1,48 @@
+package com.company.finsight.global.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
+                .responseTimeout(Duration.ofSeconds(10))
+                .doOnConnected(conn -> {
+                    conn.addHandlerLast(new ReadTimeoutHandler(5, TimeUnit.SECONDS)).addHandlerLast(new WriteTimeoutHandler(5, TimeUnit.SECONDS));
+                });
+        return WebClient.builder()
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .filter(ExchangeFilterFunction.ofRequestProcessor(clientRequest -> {
+                    log.info("Request: {} {}", clientRequest.method(), clientRequest.url());
+                    clientRequest.headers().forEach((name, values) ->
+                            values.forEach(value -> log.info("  {}: {}", name, value))
+                    );
+                    return Mono.just(clientRequest);
+                }))
+                .filter(ExchangeFilterFunction.ofResponseProcessor(clientResponse -> {
+                    log.info("Response Status: {}", clientResponse.statusCode());
+                    return Mono.just(clientResponse);
+                }));
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,10 +7,10 @@ spring:
 
   jpa:
     show-sql: false
+    hibernate:
+      ddl-auto: create
     properties:
-      hibernate:
-        ddl-auto: create
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
+      database-platform: org.hibernate.dialect.PostgreSQLDialect
 
 logging:
   level:


### PR DESCRIPTION
## 1차 크롤링 구현

## 구현 내용
1. 연합뉴스 크롤링
* WebClient를 통한 뉴스 리스트, 뉴스 본문 크롤링
* 랜덤 주기로 본문 파싱(벤 방지)
2. 응답 데이터 파싱
* Jsoup를 통해 테이블에 기입할 데이터 파싱
3. DB 저장
* 파싱한 데이터 DB 저장
4. 스케줄링 임시 적용
* 15분 주기로 새로운 뉴스 크롤링

Close #{이슈_번호}
