### PR TITLE
Feature/30일 지난 기사 삭제 로직 구현 54

### DIFF
--- a/src/main/java/com/company/finsight/api/article/crawler/parser/YNSArticleParser.java
+++ b/src/main/java/com/company/finsight/api/article/crawler/parser/YNSArticleParser.java
@@ -88,8 +88,8 @@ public class YNSArticleParser implements ArticleParser {
                 int emailDomainIndex = content.indexOf(emailDomain); // "@yna.co.kr" 시작 위치 찾기
 
                 if (emailDomainIndex != -1) {
-                    int endIndex = emailDomainIndex + emailDomain.length();
-                    content = content.substring(0, endIndex).trim();
+                    // 이메일 도메인 앞까지만 잘라내기
+                    content = content.substring(0, emailDomainIndex).trim();
                 } else {
                     // 이메일 주소가 없는 경우
                     int jeboIndex = content.indexOf("제보");

--- a/src/main/java/com/company/finsight/api/article/dto/ArticleDetailDto.java
+++ b/src/main/java/com/company/finsight/api/article/dto/ArticleDetailDto.java
@@ -13,12 +13,10 @@ import java.time.LocalDateTime;
 public class ArticleDetailDto {
     private Long id;
     private String title;
-    private String category;
     private String distributor;
     private LocalDateTime timestamp;
     private String content;
     private String reporter;
     private String source;
     private String importance;
-    private String keyword;
 }

--- a/src/main/java/com/company/finsight/api/article/dto/ArticlesDto.java
+++ b/src/main/java/com/company/finsight/api/article/dto/ArticlesDto.java
@@ -10,7 +10,6 @@ import java.time.LocalDateTime;
 public class ArticlesDto {
     private Long  id;
     private String title;
-    private String category;
     private String distributor;
     private LocalDateTime timestamp;
 }

--- a/src/main/java/com/company/finsight/api/article/repository/ArticleDslRepository.java
+++ b/src/main/java/com/company/finsight/api/article/repository/ArticleDslRepository.java
@@ -5,9 +5,31 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ArticleDslRepository {
     Page<Article> findByFilter(Pageable pageable, String category, String keyword, LocalDate period, String source);
     List<String> findContentsByIdIn(List<Long> ids);
+    
+    /**
+     * 특정 출처의 가장 최근 기사 조회
+     */
+    Optional<Article> findLatestBySource(String source);
+    
+    /**
+     * CID 목록으로 이미 존재하는 CID들만 조회 (배치 체크용)
+     */
+    List<String> findExistingCids(List<String> cids);
+    
+    /**
+     * 특정 날짜 이전의 기사 개수 조회
+     */
+    long countByPublishedAtBefore(LocalDateTime beforeDate);
+    
+    /**
+     * 특정 날짜 이전의 기사 삭제
+     */
+    int deleteByPublishedAtBefore(LocalDateTime beforeDate);
 }

--- a/src/main/java/com/company/finsight/api/article/repository/ArticleDslRepositoryImpl.java
+++ b/src/main/java/com/company/finsight/api/article/repository/ArticleDslRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.company.finsight.api.article.repository;
 
 import com.company.finsight.api.article.domain.Article;
+import com.company.finsight.global.Const;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static com.company.finsight.api.article.domain.QArticle.article;
 
@@ -34,6 +36,9 @@ public class ArticleDslRepositoryImpl implements ArticleDslRepository {
      */
     @Override
     public Page<Article> findByFilter(Pageable pageable, String category, String keyword, LocalDate period, String source) {
+        // 보관 기간 제한
+        LocalDateTime retentionCutoff = LocalDateTime.now().minusDays(Const.ARTICLE_RETENTION_DAYS);
+        
         // 쿼리 실행
         List<Article> content = queryFactory
                 .selectFrom(article)
@@ -41,7 +46,8 @@ public class ArticleDslRepositoryImpl implements ArticleDslRepository {
                         categoryEq(category),
                         keywordEq(keyword),
                         sourceEq(source),
-                        publishedAtAfter(period)
+                        publishedAtAfter(period),
+                        article.publishedAt.goe(retentionCutoff) // 보관 기간 제한
                 )
                 .orderBy(article.publishedAt.desc())
                 .offset(pageable.getOffset())
@@ -56,7 +62,8 @@ public class ArticleDslRepositoryImpl implements ArticleDslRepository {
                         categoryEq(category),
                         keywordEq(keyword),
                         sourceEq(source),
-                        publishedAtAfter(period)
+                        publishedAtAfter(period),
+                        article.publishedAt.goe(retentionCutoff) // 보관 기간 제한
                 )
                 .fetchOne();
 
@@ -108,5 +115,63 @@ public class ArticleDslRepositoryImpl implements ArticleDslRepository {
                 .from(article)
                 .where(article.id.in(ids))
                 .fetch();
+    }
+
+    /**
+     * 특정 출처의 가장 최근 기사 조회
+     */
+    @Override
+    public Optional<Article> findLatestBySource(String source) {
+        Article result = queryFactory
+                .selectFrom(article)
+                .where(article.source.eq(source))
+                .orderBy(article.publishedAt.desc())
+                .limit(1)
+                .fetchOne();
+        
+        return Optional.ofNullable(result);
+    }
+
+    /**
+     * CID 목록으로 이미 존재하는 CID들만 조회 (배치 체크용)
+     */
+    @Override
+    public List<String> findExistingCids(List<String> cids) {
+        if (cids == null || cids.isEmpty()) {
+            return List.of();
+        }
+        
+        return queryFactory
+                .select(article.articleCid)
+                .from(article)
+                .where(article.articleCid.in(cids))
+                .fetch();
+    }
+
+    /**
+     * 특정 날짜 이전의 기사 개수 조회
+     */
+    @Override
+    public long countByPublishedAtBefore(LocalDateTime beforeDate) {
+        Long count = queryFactory
+                .select(article.count())
+                .from(article)
+                .where(article.publishedAt.lt(beforeDate))
+                .fetchOne();
+        
+        return count != null ? count : 0L;
+    }
+
+    /**
+     * 특정 날짜 이전의 기사 삭제
+     */
+    @Override
+    public int deleteByPublishedAtBefore(LocalDateTime beforeDate) {
+        long deletedCount = queryFactory
+                .delete(article)
+                .where(article.publishedAt.lt(beforeDate))
+                .execute();
+        
+        return (int) deletedCount;
     }
 }

--- a/src/main/java/com/company/finsight/api/article/repository/ArticleRepository.java
+++ b/src/main/java/com/company/finsight/api/article/repository/ArticleRepository.java
@@ -2,24 +2,6 @@ package com.company.finsight.api.article.repository;
 
 import com.company.finsight.api.article.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
-import java.util.Optional;
 
 public interface ArticleRepository extends JpaRepository<Article,Long>, ArticleDslRepository {
-    
-    /**
-     * 특정 출처(source)의 가장 최근 기사 조회
-     */
-    @Query("SELECT a FROM Article a WHERE a.source = :source ORDER BY a.publishedAt DESC LIMIT 1")
-    Optional<Article> findLatestBySource(@Param("source") String source);
-    
-    /**
-     * CID 목록으로 이미 존재하는 CID들만 조회 (배치 체크용)
-     */
-    @Query("SELECT a.articleCid FROM Article a WHERE a.articleCid IN :cids")
-    List<String> findExistingCids(@Param("cids") List<String> cids);
-    
 }

--- a/src/main/java/com/company/finsight/api/article/service/ArticleService.java
+++ b/src/main/java/com/company/finsight/api/article/service/ArticleService.java
@@ -23,6 +23,7 @@ import reactor.core.scheduler.Schedulers;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.*;
 
 @Slf4j
@@ -98,7 +99,7 @@ public class ArticleService {
         return articleRepository.findContentsByIdIn(ids);
     }
 
-    @Scheduled(fixedDelay = 900000)
+    @Scheduled(fixedDelay = 900000) // 15분마다
     public void scheduledCrawlYNS() {
         log.info("스케줄링 시작...");
 
@@ -120,6 +121,37 @@ public class ArticleService {
                 .blockLast();
 
         log.info("스케줄링 종료.");
+    }
+
+    /**
+     * 30일 이상 지난 기사 삭제 (매일 새벽 2시 실행)
+     */
+    @Scheduled(cron = "0 0 2 * * *")
+    public void deleteOldArticles() {
+        log.info("오래된 기사 삭제 작업 시작...");
+        
+        try {
+            LocalDateTime cutoffDate = LocalDateTime.now().minusDays(Const.ARTICLE_RETENTION_DAYS);
+            
+            // 삭제 전 개수 확인
+            long oldArticleCount = articleRepository.countByPublishedAtBefore(cutoffDate);
+            
+            if (oldArticleCount == 0) {
+                log.info("삭제할 오래된 기사가 없습니다.");
+                return;
+            }
+            
+            log.info("{}일 이상 지난 기사 {}개 발견 (기준일: {})", 
+                    Const.ARTICLE_RETENTION_DAYS, oldArticleCount, cutoffDate);
+            
+            // 삭제 실행
+            int deletedCount = articleRepository.deleteByPublishedAtBefore(cutoffDate);
+            
+            log.info("오래된 기사 삭제 완료: {}개 삭제됨", deletedCount);
+            
+        } catch (Exception e) {
+            log.error("오래된 기사 삭제 중 오류 발생", e);
+        }
     }
 
     private Mono<List<ArticleSummaryDto>> fetchCategoryArticleList(ArticleCategory category) {

--- a/src/main/java/com/company/finsight/api/article/service/ArticleService.java
+++ b/src/main/java/com/company/finsight/api/article/service/ArticleService.java
@@ -58,7 +58,6 @@ public class ArticleService {
         return articlePage.map(article -> new ArticlesDto(
                 article.getId(),
                 article.getTitle(),
-                article.getSummary(),
                 article.getSource(),
                 article.getPublishedAt()
         ));
@@ -78,14 +77,12 @@ public class ArticleService {
         return new ArticleDetailDto(
                 article.getId(),
                 article.getTitle(),
-                article.getSummary(),
                 article.getSource(),
                 article.getPublishedAt(),
                 article.getContent(),
                 article.getReporter(),
                 article.getArticleUrl(),
-                null,                          // TODO importance (향후 구현 예정)
-                article.getKeyword()
+                null                          // TODO importance (향후 구현 예정)
         );
     }
 

--- a/src/main/java/com/company/finsight/global/Const.java
+++ b/src/main/java/com/company/finsight/global/Const.java
@@ -6,6 +6,12 @@ import java.util.Set;
 
 public class Const {
 
+    /**
+     * 기사 보관 기간 (일)
+     * 이 기간이 지난 기사는 자동으로 삭제됨
+     */
+    public static final int ARTICLE_RETENTION_DAYS = 30;
+
     public static final Set<String> KEYWORDS = new HashSet<>(Arrays.asList(
             "실적", "공시", "증시", "금리", "주가", "상승", "하락",
             "매수", "매도", "외국인", "기관", "개인",


### PR DESCRIPTION
## 작업 내용
- 30일 지난 기사 삭제 로직 구현
-  쿼리 DSL로 모든 메서드 적용
- 카테고리 응답 삭제
- 키워드 응답 삭제

## 관련 이슈

Close #54 

## 스크린샷(선택)
