### PR TITLE
feature/ai 응답 최소화 및 ai 요약 db 저장

### DIFF
--- a/src/main/java/com/company/finsight/api/ai/entity/AIArticle.java
+++ b/src/main/java/com/company/finsight/api/ai/entity/AIArticle.java
@@ -1,0 +1,52 @@
+package com.company.finsight.api.ai.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.company.finsight.api.article.domain.Article;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ai_article")
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AIArticle {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "article_id", nullable = false, unique = true)
+	private Article article;
+
+	@Column(name = "summary", columnDefinition = "TEXT", nullable = false)
+	private String summary;
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	public static AIArticle create(Article article, String summary) {
+		AIArticle ai = new AIArticle();
+		ai.article = article;
+		ai.summary = summary;
+		return ai;
+	}
+}

--- a/src/main/java/com/company/finsight/api/ai/repository/AiArticleRepository.java
+++ b/src/main/java/com/company/finsight/api/ai/repository/AiArticleRepository.java
@@ -1,0 +1,8 @@
+package com.company.finsight.api.ai.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.company.finsight.api.ai.entity.AIArticle;
+
+public interface AiArticleRepository extends JpaRepository<AIArticle, Long> {
+}

--- a/src/main/java/com/company/finsight/api/ai/service/AiService.java
+++ b/src/main/java/com/company/finsight/api/ai/service/AiService.java
@@ -10,7 +10,11 @@ import com.company.finsight.api.ai.client.AIClient;
 import com.company.finsight.api.ai.dto.SummarizeRequestDto;
 import com.company.finsight.api.ai.dto.SummarizeResponseDto;
 import com.company.finsight.api.ai.dto.SummarizeSingleRequestDto;
+import com.company.finsight.api.ai.entity.AIArticle;
+import com.company.finsight.api.ai.repository.AiArticleRepository;
+import com.company.finsight.api.article.domain.Article;
 import com.company.finsight.api.article.service.ArticleService;
+import com.company.finsight.global.cache.AiArticleCache;
 import com.company.finsight.global.exception.business.article.ArticleErrorCode;
 import com.company.finsight.global.exception.business.article.ArticleException;
 
@@ -23,6 +27,9 @@ public class AiService {
 	private final ArticleService articleService;
 	private final AIClient aiClient;
 
+	private final AiArticleRepository  aiArticleRepository;
+	private final AiArticleCache aiCache;
+
 	@Transactional(readOnly = true)
 	public SummarizeResponseDto summarize(SummarizeRequestDto requestDto) {
 		List<String> contents = articleService.findContentsByIds(requestDto.getArticleIds());
@@ -34,11 +41,30 @@ public class AiService {
 	@Transactional(readOnly = true)
 	public SummarizeResponseDto summarize(SummarizeSingleRequestDto requestDto) {
 
-		List<String> contents = articleService.findContentsByIds(List.of(requestDto.getArticleId()));
+		Long id = requestDto.getArticleId();
+
+		Optional<AIArticle> cacheAiArticleOpt = aiCache.findArticleById(id);
+		if ( cacheAiArticleOpt.isPresent() ){
+			return SummarizeResponseDto.toEntity(cacheAiArticleOpt.get().getSummary());
+		}
+
+
+		Optional<AIArticle> dbAiArticleOpt =  aiArticleRepository.findById(id);
+		if ( dbAiArticleOpt.isPresent() ){
+			aiCache.put(id, dbAiArticleOpt.get());
+			return SummarizeResponseDto.toEntity(dbAiArticleOpt.get().getSummary());
+		}
+
+		List<String> contents = articleService.findContentsByIds(List.of(id));
 		Optional<String> contentOpt = contents.stream().findFirst();
 
 		String content = contentOpt.orElseThrow(()->new ArticleException(ArticleErrorCode.ARTICLE_NOT_FOUND));
 		String summary = aiClient.summarize(content);
+
+		Article article = articleService.findArticleById(id);
+		AIArticle aiArticle = AIArticle.create(article, summary);
+
+		aiArticleRepository.save(aiArticle);
 
 		return SummarizeResponseDto.toEntity(summary);
 	}

--- a/src/main/java/com/company/finsight/api/article/domain/Article.java
+++ b/src/main/java/com/company/finsight/api/article/domain/Article.java
@@ -1,12 +1,23 @@
 package com.company.finsight.api.article.domain;
 
-import jakarta.persistence.*;
-import lombok.*;
+import java.time.LocalDateTime;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import com.company.finsight.api.ai.entity.AIArticle;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
 
 @Entity
 @Table(name = "article")
@@ -59,7 +70,10 @@ public class Article {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    public Article() {}
+	@OneToOne(mappedBy = "article", cascade = CascadeType.REMOVE)
+	private AIArticle aiArticle;
+
+	public Article() {}
 
     /**
      * Article 엔티티 생성 (정적 팩토리 메서드)

--- a/src/main/java/com/company/finsight/api/article/service/ArticleService.java
+++ b/src/main/java/com/company/finsight/api/article/service/ArticleService.java
@@ -306,4 +306,15 @@ public class ArticleService {
         }
         return String.join(", ", keywords);
     }
+
+	/**
+	 * 기사 ID 로 기사 조회
+	 *
+	 * @param id 기사 ID
+	 * @return 기사
+	 */
+	public Article findArticleById(Long id) {
+		return articleRepository.findById(id)
+			.orElseThrow(() -> new ArticleException(ArticleErrorCode.ARTICLE_NOT_FOUND));
+	}
 }

--- a/src/main/java/com/company/finsight/global/cache/AiArticleCache.java
+++ b/src/main/java/com/company/finsight/global/cache/AiArticleCache.java
@@ -1,0 +1,29 @@
+package com.company.finsight.global.cache;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.company.finsight.api.ai.entity.AIArticle;
+
+@Component
+public class AiArticleCache {
+	private static final int MAX_CACHE_SIZE = 1000;
+
+	private final Map<Long, AIArticle> cache = new LinkedHashMap<>(16, 0.75f, true) {
+		@Override
+		protected boolean removeEldestEntry(Map.Entry<Long, AIArticle> eldest) {
+			return size() > MAX_CACHE_SIZE;
+		}
+	};
+
+	public synchronized void put(Long id, AIArticle article) {
+		cache.put(id, article);
+	}
+
+	public synchronized Optional<AIArticle> findArticleById(Long id) {
+		return Optional.ofNullable(cache.get(id));
+	}
+}


### PR DESCRIPTION
## 작업 내용

- 단일 기사 AI 요약 시 캐시 조회 로직 추가
- 캐시에 없는 경우 DB 조회 후, AI 요약 수행
- 요약 결과를 캐시 및 DB에 동시에 저장
- 기사 삭제 시 캐시와 요약 DB 동기화 처리
- 인메모리 LRU 캐시 구현 (Map<Long, AIArticle>)

Close #85

